### PR TITLE
Remove Hidet dependency for server return object

### DIFF
--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -130,9 +130,9 @@ class Runner:
 
         model_id = self._get_model_id(flow_graph)
 
-        # check if cgraph is saved locally
+        # check if graph module is saved locally
         graph_module_path = os.path.join(base_path, model_id, "graph_module.zip")
-        if os.path.isfile(graph_module_path):  # cgraph is saved locally
+        if os.path.isfile(graph_module_path):
             with open(graph_module_path, "rb") as f:
                 graph_module = pickle.load(f)
         else:

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -83,7 +83,7 @@ class Runner:
         download_path = os.path.join(download_dir, "graph_module.zip")
         with open(download_path, "wb") as f:
             f.write(download_response.content)
-        return torch.load(download_path)
+            return pickle.loads(download_response.content)
 
     def _compile_model(self, model_id: str):
         compile_response = requests.post(
@@ -133,7 +133,8 @@ class Runner:
         # check if cgraph is saved locally
         graph_module_path = os.path.join(base_path, model_id, "graph_module.zip")
         if os.path.isfile(graph_module_path):  # cgraph is saved locally
-            graph_module = torch.load(graph_module_path)
+            with open(graph_module_path, "rb") as f:
+                graph_module = pickle.load(f)
         else:
             self._wait_for_status(model_id)
             graph_module = self._download_model(model_id)
@@ -149,7 +150,7 @@ class Runner:
             torch.cuda.empty_cache()
 
     def __call__(self, *args, **kwargs):
-        # # If model is currently compiling, return the uncompiled forward function
+        # If model is currently compiling, return the uncompiled forward function
         with self.lock:
             if not self.compiled_forward_function:
                 return self.module.forward(*args, **kwargs)

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -155,7 +155,8 @@ class Runner:
             if not self.compiled_forward_function:
                 return self.module.forward(*args, **kwargs)
 
-        return self.compiled_forward_function(*args)
+        # The torch.fx.GraphModule compiled forward function expects arguments to be passed as a tuple
+        return self.compiled_forward_function(args)
 
 
 def centml_dynamo_backend(gm: GraphModule, example_inputs: List[torch.Tensor]):

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -155,8 +155,7 @@ class Runner:
             if not self.compiled_forward_function:
                 return self.module.forward(*args, **kwargs)
 
-        # The torch.fx.GraphModule compiled forward function expects arguments to be passed as a tuple
-        return self.compiled_forward_function(args)
+        return self.compiled_forward_function(*args)
 
 
 def centml_dynamo_backend(gm: GraphModule, example_inputs: List[torch.Tensor]):

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -33,7 +33,6 @@ class Runner:
 
         try:
             self.child_thread.start()
-            raise Exception("Remote compilation failed to start in a separate thread.")
         except Exception:
             logging.getLogger(__name__).exception("Remote compilation failed with the following exception: \n")
 

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -149,7 +149,7 @@ class Runner:
             gc.collect()
             torch.cuda.empty_cache()
 
-    def __call__(self, *args, **kwargs):  
+    def __call__(self, *args, **kwargs):
         # If model is currently compiling, return the uncompiled forward function
         with self.lock:
             if not self.compiled_forward_function:

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -20,9 +20,6 @@ from centml.compiler.config import config_instance, CompilationStatus
 from centml.compiler.utils import get_backend_compiled_forward_path
 
 
-hidet.option.imperative(False)
-
-
 class Runner:
     def __init__(self, module: GraphModule, inputs: List[torch.Tensor]):
         self._module: GraphModule = weakref.ref(module)

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -74,7 +74,6 @@ class Runner:
                 f"Download: request failed, exception from server:\n{download_response.json().get('detail')}"
             )
         download_path = get_backend_compiled_forward_path(model_id)
-        os.makedirs(os.path.dirname(download_path), exist_ok=True)
         with open(download_path, "wb") as f:
             f.write(download_response.content)
             return pickle.loads(download_response.content)

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -2,6 +2,7 @@ import os
 from enum import Enum
 import hidet
 
+
 class CompilationStatus(Enum):
     NOT_FOUND = "not_found"
     COMPILING = "compiling"
@@ -20,6 +21,7 @@ class Config:
 
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
+
 
 config_instance = Config()
 hidet.option.imperative(False)

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -16,6 +16,10 @@ class Config:
     CACHE_PATH = os.getenv("CENTML_CACHE_DIR", default=os.path.expanduser("~/.cache/centml"))
     SERVER_IP = os.getenv("CENTML_SERVER_IP", default="0.0.0.0")
     SERVER_PORT = os.getenv("CENTML_SERVER_PORT", default="8080")
+    SERVER_URL = f"http://{SERVER_IP}:{SERVER_PORT}"
+
+    BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
+    SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
 
 config_instance = Config()

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-
+import hidet
 
 class CompilationStatus(Enum):
     NOT_FOUND = "not_found"
@@ -21,5 +21,5 @@ class Config:
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
-
 config_instance = Config()
+hidet.option.imperative(False)

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -2,6 +2,8 @@ import os
 from enum import Enum
 import hidet
 
+hidet.option.imperative(False)
+
 
 class CompilationStatus(Enum):
     NOT_FOUND = "not_found"
@@ -24,4 +26,3 @@ class Config:
 
 
 config_instance = Config()
-hidet.option.imperative(False)

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -16,12 +16,10 @@ app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 
 def get_status(model_id: str):
-    path = get_server_compiled_forward_path(model_id)
-
-    if not os.path.isdir(os.path.dirname(path)):
+    if not os.path.isdir(os.path.join(config_instance.SERVER_BASE_PATH, model_id)):
         return CompilationStatus.NOT_FOUND
 
-    if not os.path.isfile(path):
+    if not os.path.isfile(get_server_compiled_forward_path(model_id)):
         return CompilationStatus.COMPILING
 
     return CompilationStatus.DONE

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -39,7 +39,7 @@ async def status_handler(model_id: str):
 
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
-        # This will save the cgraph to {storage_path}/{model_id}/cgraph.zip
+        # This will save the compiled torch.fx.GraphModule to {storage_path}/{model_id}/graph_module.zip
         hidet_backend_server(tfx_graph, example_inputs, model_id)
     except Exception as e:
         logger.exception(f"Compilation: error compiling model. {e}")

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -40,10 +40,16 @@ async def status_handler(model_id: str):
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
         # This will save the compiled torch.fx.GraphModule to {storage_path}/{model_id}/graph_module.zip
-        hidet_backend_server(tfx_graph, example_inputs, model_id)
+        graph_module = hidet_backend_server(tfx_graph, example_inputs)
     except Exception as e:
         logger.exception(f"Compilation: error compiling model. {e}")
         dir_cleanup(model_id)
+
+    try:
+        with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:
+            pickle.dump(graph_module, f)
+    except Exception as e:
+        raise Exception("Saving graph module failed") from e
 
 
 def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -19,10 +19,10 @@ def get_status(model_id: str):
     if not os.path.isdir(os.path.join(storage_path, model_id)):
         return CompilationStatus.NOT_FOUND
 
-    if not os.path.isfile(os.path.join(storage_path, model_id, "cgraph.zip")):
+    if not os.path.isfile(os.path.join(storage_path, model_id, "graph_module.zip")):
         return CompilationStatus.COMPILING
 
-    if os.path.isfile(os.path.join(storage_path, model_id, "cgraph.zip")):
+    if os.path.isfile(os.path.join(storage_path, model_id, "graph_module.zip")):
         return CompilationStatus.DONE
 
     return None
@@ -92,7 +92,7 @@ async def compile_model_handler(model_id: str, model: UploadFile, inputs: Upload
 
 @app.get("/download/{model_id}")
 async def download_handler(model_id: str):
-    compiled_forward_path = os.path.join(storage_path, model_id, "cgraph.zip")
+    compiled_forward_path = os.path.join(storage_path, model_id, "graph_module.zip")
     if not os.path.isfile(compiled_forward_path):
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Download: compiled file not found")
     return FileResponse(compiled_forward_path)

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -40,16 +40,10 @@ async def status_handler(model_id: str):
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
         # This will save the compiled torch.fx.GraphModule to {storage_path}/{model_id}/graph_module.zip
-        graph_module = hidet_backend_server(tfx_graph, example_inputs)
+        hidet_backend_server(tfx_graph, example_inputs, model_id)
     except Exception as e:
         logger.exception(f"Compilation: error compiling model. {e}")
         dir_cleanup(model_id)
-
-    try:
-        with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:
-            pickle.dump(graph_module, f)
-    except Exception as e:
-        raise Exception("Saving graph module failed") from e
 
 
 def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -16,10 +16,12 @@ app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 
 def get_status(model_id: str):
-    if not os.path.isdir(os.path.join(config_instance.SERVER_BASE_PATH, model_id)):
+    path = get_server_compiled_forward_path(model_id)
+
+    if not os.path.isdir(os.path.dirname(path)):
         return CompilationStatus.NOT_FOUND
 
-    if not os.path.isfile(get_server_compiled_forward_path(model_id)):
+    if not os.path.isfile(path):
         return CompilationStatus.COMPILING
 
     return CompilationStatus.DONE

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -39,7 +39,7 @@ async def status_handler(model_id: str):
 
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
-        # This will save the compiled torch.fx.GraphModule to {storage_path}/{model_id}/graph_module.zip
+        # This will save the compiled return class to {storage_path}/{model_id}/graph_module.zip
         hidet_backend_server(tfx_graph, example_inputs, model_id)
     except Exception as e:
         logger.exception(f"Compilation: error compiling model. {e}")

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -37,31 +37,6 @@ async def status_handler(model_id: str):
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Status check: invalid status state.")
 
 
-async def read_upload_files(model_id, model: UploadFile, inputs: UploadFile):
-    try:
-        tfx_contents = await model.read()
-        ei_contents = await inputs.read()
-    except Exception as e:
-        dir_cleanup(model_id)
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Compilation: error reading serialized content."
-        ) from e
-    finally:
-        model.file.close()
-        inputs.file.close()
-
-    try:
-        tfx_graph = pickle.loads(tfx_contents)
-        example_inputs = pickle.loads(ei_contents)
-    except Exception as e:
-        dir_cleanup(model_id)
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Compilation: error loading pickled content."
-        ) from e
-
-    return tfx_graph, example_inputs
-
-
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
         # This will save the compiled torch.fx.GraphModule to {storage_path}/{model_id}/graph_module.zip

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -6,26 +6,23 @@ import uvicorn
 from fastapi import FastAPI, UploadFile, HTTPException, BackgroundTasks, Response
 from fastapi.responses import FileResponse
 from fastapi.middleware.gzip import GZipMiddleware
-from centml.compiler.server_compilation import hidet_backend_server, storage_path, dir_cleanup
+from centml.compiler.server_compilation import hidet_backend_server
+from centml.compiler.utils import dir_cleanup
 from centml.compiler.config import config_instance, CompilationStatus
-
-logger = logging.getLogger(__name__)
+from centml.compiler.utils import get_server_compiled_forward_path
 
 app = FastAPI()
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 
 def get_status(model_id: str):
-    if not os.path.isdir(os.path.join(storage_path, model_id)):
+    if not os.path.isdir(os.path.join(config_instance.SERVER_BASE_PATH, model_id)):
         return CompilationStatus.NOT_FOUND
 
-    if not os.path.isfile(os.path.join(storage_path, model_id, "graph_module.zip")):
+    if not os.path.isfile(get_server_compiled_forward_path(model_id)):
         return CompilationStatus.COMPILING
 
-    if os.path.isfile(os.path.join(storage_path, model_id, "graph_module.zip")):
-        return CompilationStatus.DONE
-
-    return None
+    return CompilationStatus.DONE
 
 
 @app.get("/status/{model_id}")
@@ -39,10 +36,10 @@ async def status_handler(model_id: str):
 
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
-        # This will save the compiled return class to {storage_path}/{model_id}/graph_module.zip
+        # This will save the compiled return object to the server cache
         hidet_backend_server(tfx_graph, example_inputs, model_id)
     except Exception as e:
-        logger.exception(f"Compilation: error compiling model. {e}")
+        logging.getLogger(__name__).exception(f"Compilation: error compiling model. {e}")
         dir_cleanup(model_id)
 
 
@@ -82,7 +79,7 @@ async def compile_model_handler(model_id: str, model: UploadFile, inputs: Upload
         return Response(status_code=200)
 
     # This effectively sets the model's status to COMPILING
-    os.makedirs(os.path.join(storage_path, model_id))
+    os.makedirs(os.path.join(config_instance.SERVER_BASE_PATH, model_id))
 
     tfx_graph, example_inputs = read_upload_files(model_id, model, inputs)
 
@@ -92,7 +89,7 @@ async def compile_model_handler(model_id: str, model: UploadFile, inputs: Upload
 
 @app.get("/download/{model_id}")
 async def download_handler(model_id: str):
-    compiled_forward_path = os.path.join(storage_path, model_id, "graph_module.zip")
+    compiled_forward_path = get_server_compiled_forward_path(model_id)
     if not os.path.isfile(compiled_forward_path):
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Download: compiled file not found")
     return FileResponse(compiled_forward_path)

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -1,7 +1,4 @@
-import os
 import pickle
-import shutil
-import logging
 from enum import Enum
 from typing import List, Callable
 import torch
@@ -15,6 +12,7 @@ from hidet.graph.frontend.torch.dynamo_backends import (
     HidetCompiledModel,
 )
 from centml.compiler.utils import get_server_compiled_forward_path
+
 
 class CompilerType(Enum):
     HIDET = "hidet"

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -1,8 +1,9 @@
 import os
+import pickle
 import shutil
 import logging
-from typing import List
-import pickle
+from enum import Enum
+from typing import List, Callable
 import torch
 from torch.fx import GraphModule
 from hidet.graph.frontend import from_torch
@@ -21,48 +22,6 @@ os.makedirs(storage_path, exist_ok=True)
 logger = logging.getLogger(__name__)
 
 
-# Calling the torch.fx.GraphModule will call RootModule.forward
-# Due to limitations on how the GraphModule is constructed, args are passed as a tuple and later unpacked
-class RootModule(torch.nn.Module):
-    def __init__(self, callable):
-        super().__init__()
-        self.leaf_module = callable
-
-    def forward(self, args):
-        return self.leaf_module(args)
-
-
-# We wrap the callable in a torch.nn.Module so that it can be a leaf module in the graph
-# Leaf modules avoid being traced by the torch.fx.Tracer and are treated like black boxes
-class ModuleWrapper(torch.nn.Module):
-    def __init__(self, callable):
-        super().__init__()
-        self.callable = callable
-
-    def forward(self, args):
-        return self.callable(*args)
-
-
-# Note: pickling a GraphModule won't save its Graph.
-# Instead, it stores the Tracer and re-traces to recreate the Graph when deserializing.
-class CustomTracer(torch.fx.Tracer):
-    # Don't trace the ModuleWrapper
-    def is_leaf_module(self, m, module_qualified_name):
-        if isinstance(m, ModuleWrapper):
-            return True
-        return super().is_leaf_module(m, module_qualified_name)
-
-
-# Create a torch.fx.GraphModule that wraps around `callable`.
-# `callable` is a class whose forward function gets called when we call the GraphModule's forward function
-def get_graph_module(callable):
-    module = ModuleWrapper(callable)
-    root = RootModule(module)
-    tracer = CustomTracer()
-    graph = tracer.trace(root)
-    return GraphModule(root, graph)
-
-
 # This function will delete the storage_path/{model_id} directory
 def dir_cleanup(model_id: str):
     dir_path = os.path.join(storage_path, model_id)
@@ -76,6 +35,28 @@ def dir_cleanup(model_id: str):
         shutil.rmtree(dir_path)
     except Exception as e:
         raise Exception("Failed to delete the directory") from e
+
+
+class CompilerType(Enum):
+    HIDET = "hidet"
+
+
+class RootRCModule(Callable):
+    def __init__(self, compiler_name: CompilerType):
+        self.compiler_name = compiler_name
+
+    # Implement in child class
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+class HidetRCModule(RootRCModule):
+    def __init__(self, hidet_compiled_model):
+        super().__init__(CompilerType.HIDET)
+        self.compiled_model_forward = hidet_compiled_model
+
+    def __call__(self, *args, **kwargs):
+        return self.compiled_model_forward(*args)
 
 
 def hidet_backend_server(input_graph_module: GraphModule, example_inputs: List[torch.Tensor], model_id: str):
@@ -94,7 +75,7 @@ def hidet_backend_server(input_graph_module: GraphModule, example_inputs: List[t
     wrapper = HidetCompiledModel(cgraph, hidet_inputs, output_format)
 
     # Wrap the forward function in a torch.fx.GraphModule
-    compiled_graph_module = get_graph_module(wrapper)
+    compiled_graph_module = HidetRCModule(wrapper)
 
     try:
         with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -13,6 +13,7 @@ from hidet.graph.frontend.torch.dynamo_backends import (
     CompiledForwardFunction,
 )
 from centml.compiler.config import config_instance
+import pickle
 
 storage_path = os.path.join(config_instance.CACHE_PATH, "server")
 os.makedirs(storage_path, exist_ok=True)
@@ -73,9 +74,10 @@ def hidet_backend_server(graph_module: GraphModule, example_inputs: List[torch.T
 
     # Wrap the forward function in a torch.fx.GraphModule
     graph_module = get_graph_module(wrapper, example_inputs)
-
+    
     try:
         # This uses pickle to serialize to disk
-        torch.save(graph_module, os.path.join(storage_path, model_id, "graph_module.zip"))
+        with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:
+            pickle.dump(graph_module, f)
     except Exception as e:
         raise Exception("Saving graph module failed") from e

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 
 # Custom tracer that doesn't trace the callable (it treats it as a leaf module)
 class CustomTracer(torch.fx.Tracer):
-    def __init__(self, callable):
-        super().__init__()
+    def __init__(self, callable=CompiledForwardFunction):
         self.callable_type = type(callable)
+        super().__init__()
 
     def is_leaf_module(self, m, module_qualified_name):
         if isinstance(m, self.callable_type):

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import logging
 from typing import List
-import torch
 import pickle
+import torch
 from torch.fx import GraphModule
 from hidet.graph.frontend import from_torch
 from hidet.graph.frontend.torch.interpreter import Interpreter

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -2,19 +2,40 @@ import os
 import shutil
 import logging
 from typing import List
-from torch import Tensor
-from torch.fx import GraphModule
-from hidet.runtime.compiled_graph import save_compiled_graph
+import torch
+from torch.fx import GraphModule, Graph
 from hidet.graph.frontend import from_torch
 from hidet.graph.frontend.torch.interpreter import Interpreter
-from hidet.graph.frontend.torch.dynamo_backends import get_flow_graph, get_compiled_graph, preprocess_inputs
+from hidet.graph.frontend.torch.dynamo_backends import (
+    get_flow_graph,
+    get_compiled_graph,
+    preprocess_inputs,
+    CompiledForwardFunction,
+)
 from centml.compiler.config import config_instance
-
 
 storage_path = os.path.join(config_instance.CACHE_PATH, "server")
 os.makedirs(storage_path, exist_ok=True)
 
 logger = logging.getLogger(__name__)
+
+
+# Create a torch.fx.GraphModule that wraps around `callable`
+# graph_module(*inputs) will call callable.__call__(*inputs)
+# In this function, `example_inputs`` is only used to determine the number of input nodes
+def get_graph_module(callable, example_inputs):
+    graph = Graph()
+    input_nodes = [
+        graph.create_node(op='placeholder', target=f'input_{i}', args=(), kwargs={}) for i in range(len(example_inputs))
+    ]
+
+    # This should call "__call__" method of `callable` (the root)
+    function_node = graph.create_node(op='call_module', target="__call__", args=tuple(input_nodes), kwargs={})
+    graph.output(function_node)
+
+    graph_module = GraphModule(callable, graph)
+
+    return graph_module
 
 
 # This function will delete the storage_path/{model_id} directory
@@ -32,21 +53,29 @@ def dir_cleanup(model_id: str):
         raise Exception("Failed to delete the directory") from e
 
 
-def hidet_backend_server(graph_module: GraphModule, example_inputs: List[Tensor], model_id: str):
+def hidet_backend_server(graph_module: GraphModule, example_inputs: List[torch.Tensor], model_id: str):
     assert isinstance(graph_module, GraphModule)
 
     logger.info("received a subgraph with %d nodes to optimize", len(graph_module.graph.nodes))
     logger.debug("graph: %s", graph_module.graph)
 
+    # Create hidet compiled graph
     interpreter: Interpreter = from_torch(graph_module)
-    flow_graph, _, _ = get_flow_graph(interpreter, example_inputs)
+    flow_graph, _, output_format = get_flow_graph(interpreter, example_inputs)
     cgraph = get_compiled_graph(flow_graph)
 
-    # perform inference using example inputs to get dispatch table
+    # Perform inference using example inputs to get dispatch table
     hidet_inputs = preprocess_inputs(example_inputs)
     cgraph.run_async(hidet_inputs)
 
+    # Get compiled forward function
+    wrapper = CompiledForwardFunction(cgraph, example_inputs, output_format)
+
+    # Wrap the forward function in a torch.fx.GraphModule
+    graph_module = get_graph_module(wrapper, example_inputs)
+
     try:
-        save_compiled_graph(cgraph, os.path.join(storage_path, model_id, "cgraph.zip"), save_dispatch_table=True)
+        # This uses pickle to serialize to disk
+        torch.save(graph_module, os.path.join(storage_path, model_id, "graph_module.zip"))
     except Exception as e:
-        raise Exception("Saving compiled graph failed") from e
+        raise Exception("Saving graph module failed") from e

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -3,7 +3,7 @@ import shutil
 import logging
 from typing import List
 import torch
-from torch.fx import GraphModule, Graph
+from torch.fx import GraphModule, Graph, Tracer
 from hidet.graph.frontend import from_torch
 from hidet.graph.frontend.torch.interpreter import Interpreter
 from hidet.graph.frontend.torch.dynamo_backends import (
@@ -13,6 +13,7 @@ from hidet.graph.frontend.torch.dynamo_backends import (
     CompiledForwardFunction,
 )
 from centml.compiler.config import config_instance
+import types
 import pickle
 
 storage_path = os.path.join(config_instance.CACHE_PATH, "server")
@@ -20,28 +21,33 @@ os.makedirs(storage_path, exist_ok=True)
 
 logger = logging.getLogger(__name__)
 
+class CustomTracer(torch.fx.Tracer):
+#     # def __init__(self, root):
+#     #     super().__init__()
+#     #     self.root = root
+    
+    def is_leaf_module(self, m, module_qualified_name):
+        print("CALLED")
+        if isinstance(m, CompiledForwardFunction):
+            return True
+        return super().is_leaf_module(m, module_qualified_name)
+
+class MyModule(torch.nn.Module):
+    def __init__(self, cff):
+        super().__init__()
+        self.leaf_module = cff
+    
+    def forward(self, x):
+        return self.leaf_module(x)
 
 # Create a torch.fx.GraphModule that wraps around `callable`
 # graph_module(*inputs) will call callable.__call__(*inputs)
 # In this function, `example_inputs`` is only used to determine the number of input nodes
 def get_graph_module(callable, example_inputs):
-    graph = Graph()
-    input_nodes = [
-        graph.create_node(op='placeholder', target=f'input_{i}', args=(), kwargs={}) for i in range(len(example_inputs))
-    ]
-    
-    # Create a `get_attr` node that refers to `callable`
-    callable_node = graph.create_node(op='get_attr', target='callable')
-
-    # This should call "__call__" method of `callable` (the root)
-    function_node = graph.create_node(op='call_method', target="__call__", args=(callable_node, *input_nodes), kwargs={})
-    graph.output(function_node)
-    
-    # Make `callable` an attribute of a new parent module
-    parent_module = torch.nn.Module()
-    parent_module.callable = callable
-
-    graph_module = GraphModule(parent_module, graph)
+    module = MyModule(callable)
+    tracer = CustomTracer()
+    graph = tracer.trace(module, example_inputs)
+    graph_module = GraphModule(module, graph)
 
     return graph_module
 
@@ -60,7 +66,6 @@ def dir_cleanup(model_id: str):
     except Exception as e:
         raise Exception("Failed to delete the directory") from e
 
-
 def hidet_backend_server(graph_module: GraphModule, example_inputs: List[torch.Tensor], model_id: str):
     assert isinstance(graph_module, GraphModule)
 
@@ -77,13 +82,13 @@ def hidet_backend_server(graph_module: GraphModule, example_inputs: List[torch.T
     cgraph.run_async(hidet_inputs)
 
     # Get compiled forward function
-    wrapper = CompiledForwardFunction(cgraph, example_inputs, output_format)
-
+    wrapper = CompiledForwardFunction(cgraph, hidet_inputs, output_format)
+    
     # Wrap the forward function in a torch.fx.GraphModule
     graph_module = get_graph_module(wrapper, example_inputs)
-    
+
     graph_module.graph.print_tabular()
-    
+
     try:
         # This uses pickle to serialize to disk
         with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:

--- a/centml/compiler/utils.py
+++ b/centml/compiler/utils.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+from centml.compiler.config import config_instance
+
+
+def get_backend_compiled_forward_path(model_id: str):
+    os.makedirs(config_instance.BACKEND_BASE_PATH, exist_ok=True)
+    return os.path.join(config_instance.BACKEND_BASE_PATH, model_id, "compilation_return.pkl")
+
+
+def get_server_compiled_forward_path(model_id: str):
+    os.makedirs(config_instance.SERVER_BASE_PATH, exist_ok=True)
+    return os.path.join(config_instance.SERVER_BASE_PATH, model_id, "compilation_return.pkl")
+
+
+# This function will delete the storage_path/{model_id} directory
+def dir_cleanup(model_id: str):
+    dir_path = os.path.join(config_instance.SERVER_BASE_PATH, model_id)
+    if not os.path.exists(dir_path):
+        return  # Directory does not exist, return
+
+    if not os.path.isdir(dir_path):
+        raise Exception(f"'{dir_path}' is not a directory")
+
+    try:
+        shutil.rmtree(dir_path)
+    except Exception as e:
+        raise Exception("Failed to delete the directory") from e

--- a/centml/compiler/utils.py
+++ b/centml/compiler/utils.py
@@ -4,12 +4,12 @@ from centml.compiler.config import config_instance
 
 
 def get_backend_compiled_forward_path(model_id: str):
-    os.makedirs(config_instance.BACKEND_BASE_PATH, exist_ok=True)
+    os.makedirs(os.path.join(config_instance.BACKEND_BASE_PATH, model_id), exist_ok=True)
     return os.path.join(config_instance.BACKEND_BASE_PATH, model_id, "compilation_return.pkl")
 
 
 def get_server_compiled_forward_path(model_id: str):
-    os.makedirs(config_instance.SERVER_BASE_PATH, exist_ok=True)
+    os.makedirs(os.path.join(config_instance.SERVER_BASE_PATH, model_id), exist_ok=True)
     return os.path.join(config_instance.SERVER_BASE_PATH, model_id, "compilation_return.pkl")
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 black>=23.10.0
 pylint>=3.0.1
 pytest>=7.4.0
+pytest-env>=1.1.3
 transformers>=4.34.1
 httpx>=0.25.0
 Pillow>=10.1.0

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -447,6 +447,7 @@ disable=raw-checker-failed,
         import-error,
         bad-option-value,
         protected-access,
+        broad-except,
         broad-exception-raised,
         broad-exception-caught,
         no-member,                          # too many false positives

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -109,7 +109,7 @@ class TestDownloadModel(SetUpGraphModule):
 
     @patch("os.makedirs")
     @patch("builtins.open")
-    @patch("centml.compiler.backend.load_compiled_graph")
+    @patch("centml.compiler.backend.pickle.loads")
     @patch("centml.compiler.backend.requests")
     def test_successful_download(self, mock_requests, mock_load, mock_open, mock_makedirs):
         # Mock the response from the requests library
@@ -197,11 +197,16 @@ class TestRemoteCompilation(TestCase):
         torch._dynamo.reset()
 
     @patch("os.path.isfile", new=lambda x: True)
-    @patch("centml.compiler.backend.load_compiled_graph")
-    def test_cgraph_saved(self, mock_load):
+    @patch("builtins.open")
+    @patch("centml.compiler.backend.pickle.load")
+    def test_cgraph_saved(self, mock_load, mock_open):
         mock_load.return_value = MagicMock()
 
-        self.call_remote_compilation()
+        # Don't calculate the model_id since that saves a temp file. Just return "1234"
+        with patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234"):
+            self.call_remote_compilation()
+
+        mock_open.assert_called_once()
         mock_load.assert_called_once()
 
     @patch('os.path.isfile', new=lambda x: False)
@@ -211,6 +216,9 @@ class TestRemoteCompilation(TestCase):
         mock_status.return_value = True
         mock_download.return_value = MagicMock()
 
-        self.call_remote_compilation()
+        # Don't calculate the model_id since that saves a temp file. Just return "1234"
+        with patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234"):
+            self.call_remote_compilation()
+
         mock_status.assert_called_once()
         mock_download.assert_called_once()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -125,7 +125,7 @@ class TestDownloadModel(SetUpGraphModule):
         mock_requests.get.assert_called_once()
         mock_load.assert_called_once()
         mock_open.assert_called_once()
-        mock_makedirs.assert_called_once()
+        self.assertEqual(mock_makedirs.call_count, 2)
 
 
 class TestWaitForStatus(SetUpGraphModule):
@@ -199,12 +199,11 @@ class TestRemoteCompilation(TestCase):
     @patch("os.path.isfile", new=lambda x: True)
     @patch("builtins.open")
     @patch("centml.compiler.backend.pickle.load")
-    def test_graph_module_saved(self, mock_load, mock_open):
+    @patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234")
+    def test_compiled_return_saved(self, mock_load, mock_open):
         mock_load.return_value = MagicMock()
 
-        # Don't calculate the model_id since that saves a temp file. Just return "1234"
-        with patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234"):
-            self.call_remote_compilation()
+        self.call_remote_compilation()
 
         mock_open.assert_called_once()
         mock_load.assert_called_once()
@@ -212,13 +211,12 @@ class TestRemoteCompilation(TestCase):
     @patch('os.path.isfile', new=lambda x: False)
     @patch('centml.compiler.backend.Runner._download_model')
     @patch('centml.compiler.backend.Runner._wait_for_status')
-    def test_graph_module_not_saved(self, mock_status, mock_download):
+    @patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234")
+    def test_compiled_return_not_saved(self, mock_status, mock_download):
         mock_status.return_value = True
         mock_download.return_value = MagicMock()
 
-        # Don't calculate the model_id since that saves a temp file. Just return "1234"
-        with patch("centml.compiler.backend.Runner._get_model_id", new=lambda x, y: "1234"):
-            self.call_remote_compilation()
+        self.call_remote_compilation()
 
         mock_status.assert_called_once()
         mock_download.assert_called_once()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -199,7 +199,7 @@ class TestRemoteCompilation(TestCase):
     @patch("os.path.isfile", new=lambda x: True)
     @patch("builtins.open")
     @patch("centml.compiler.backend.pickle.load")
-    def test_cgraph_saved(self, mock_load, mock_open):
+    def test_graph_module_saved(self, mock_load, mock_open):
         mock_load.return_value = MagicMock()
 
         # Don't calculate the model_id since that saves a temp file. Just return "1234"
@@ -212,7 +212,7 @@ class TestRemoteCompilation(TestCase):
     @patch('os.path.isfile', new=lambda x: False)
     @patch('centml.compiler.backend.Runner._download_model')
     @patch('centml.compiler.backend.Runner._wait_for_status')
-    def test_cgraph_not_saved(self, mock_status, mock_download):
+    def test_graph_module_not_saved(self, mock_status, mock_download):
         mock_status.return_value = True
         mock_download.return_value = MagicMock()
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -125,7 +125,7 @@ class TestDownloadModel(SetUpGraphModule):
         mock_requests.get.assert_called_once()
         mock_load.assert_called_once()
         mock_open.assert_called_once()
-        self.assertEqual(mock_makedirs.call_count, 2)
+        mock_makedirs.assert_called_once()
 
 
 class TestWaitForStatus(SetUpGraphModule):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,10 +49,10 @@ class TestStatusHandler(TestCase):
 @parameterized_class(list(MODEL_SUITE.values()))
 class TestBackgroundCompile(TestCase):
     @pytest.mark.gpu
-    @patch("centml.compiler.server_compilation.save_compiled_graph")
+    @patch("centml.compiler.server_compilation.open")
     @patch("logging.Logger.exception")
     @patch("threading.Thread.start", new=lambda x: None)
-    def test_successful_compilation(self, mock_logger, mock_save_cgraph):
+    def test_successful_compilation(self, mock_logger, mock_open):
         # For some reason there is a deadlock with parallel builds
         hidet.option.parallel_build(False)
         warnings.filterwarnings("ignore", category=UserWarning)
@@ -71,8 +71,8 @@ class TestBackgroundCompile(TestCase):
         model_id = "successful_model"
         background_compile(model_id, graph_module, example_inputs)
 
+        mock_open.assert_called_once()
         mock_logger.assert_not_called()
-        mock_save_cgraph.assert_called_once()
 
 
 class TestReadUploadFiles(TestCase):


### PR DESCRIPTION
Instead of returning a Hidet `CompiledGraph` to the client, the server should return a `torch.fx.GraphModule`.

Here, it returns a `GraphModule` that simply wraps around the `CompiledGraph`'s compiled forward function.
(Note: the `GraphModule` does NOT trace through the forward function and just treats it like a blackbox. Tracing would probably try to optimize the forward function but hidet's forward function has a dynamic control flow which isn't easily traceable)

The `GraphModule`'s graph looks like:
```
opcode       name         target       args            kwargs
-----------  -----------  -----------  --------------  --------
placeholder  x            x            ()              {}
call_module  leaf_module  leaf_module  (x,)            {}
output       output       output       (leaf_module,)  {}
```
It expects all arguments to the forward function it wraps to be passed as a tuple.