### PR TITLE
[Fix] Bad Import

### DIFF
--- a/centml/cli/main.py
+++ b/centml/cli/main.py
@@ -15,9 +15,9 @@ cli.add_command(logout)
 
 @cli.command(help="Start remote compilation server")
 def server():
-    from ..compiler import server
+    from ..compiler.server import run
 
-    server.run()
+    run()
 
 
 @click.group(help="CentML cluster CLI tool")

--- a/centml/cli/main.py
+++ b/centml/cli/main.py
@@ -15,9 +15,9 @@ cli.add_command(logout)
 
 @cli.command(help="Start remote compilation server")
 def server():
-    from .. import compiler
+    from ..compiler import server
 
-    compiler.server.run()
+    server.run()
 
 
 @click.group(help="CentML cluster CLI tool")


### PR DESCRIPTION
I was getting the error 

`AttributeError: module 'centml.compiler' has no attribute 'server'`

on the line

`compiler.server.run()`

This fixes the import