### PR TITLE
Compile_server, save compiled model in background task function

### DIFF
--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -36,11 +36,16 @@ async def status_handler(model_id: str):
 
 def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
-        # This will save the compiled return object to the server cache
-        hidet_backend_server(tfx_graph, example_inputs, model_id)
+        compiled_graph_module = hidet_backend_server(tfx_graph, example_inputs)
     except Exception as e:
         logging.getLogger(__name__).exception(f"Compilation: error compiling model. {e}")
         dir_cleanup(model_id)
+
+    try:
+        with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:
+            pickle.dump(compiled_graph_module, f)
+    except Exception as e:
+        raise Exception("Saving graph module failed") from e
 
 
 def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -42,10 +42,11 @@ def background_compile(model_id: str, tfx_graph, example_inputs):
         dir_cleanup(model_id)
 
     try:
-        with open(os.path.join(storage_path, model_id, "graph_module.zip"), "wb") as f:
+        save_path = get_server_compiled_forward_path(model_id)
+        with open(save_path, "wb") as f:
             pickle.dump(compiled_graph_module, f)
     except Exception as e:
-        raise Exception("Saving graph module failed") from e
+        raise Exception(f"Saving graph module failed: {e}") from e
 
 
 def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -3,7 +3,6 @@ from typing import List, Callable
 import torch
 from torch.fx import GraphModule
 from hidet.graph.frontend import from_torch
-from hidet.runtime.compiled_graph import CompiledGraph
 from hidet.graph.frontend.torch.interpreter import Interpreter
 from hidet.graph.frontend.torch.dynamo_backends import (
     get_flow_graph,

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -35,7 +35,7 @@ class HidetRCReturn(BaseRCReturn):
         return self.compiled_model_forward(*args)
 
 
-def hidet_backend_server(input_graph_module: GraphModule, example_inputs: List[torch.Tensor]) -> CompiledGraph:
+def hidet_backend_server(input_graph_module: GraphModule, example_inputs: List[torch.Tensor]):
     assert isinstance(input_graph_module, GraphModule)
 
     # Create hidet compiled graph

--- a/centml/compiler/server_compilation.py
+++ b/centml/compiler/server_compilation.py
@@ -11,7 +11,6 @@ from hidet.graph.frontend.torch.dynamo_backends import (
     preprocess_inputs,
     HidetCompiledModel,
 )
-from centml.compiler.utils import get_server_compiled_forward_path
 
 
 class CompilerType(Enum):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,7 +49,7 @@ class TestStatusHandler(TestCase):
 @parameterized_class(list(MODEL_SUITE.values()))
 class TestBackgroundCompile(TestCase):
     @pytest.mark.gpu
-    @patch("centml.compiler.server_compilation.open")
+    @patch("centml.compiler.server.open")
     @patch("logging.Logger.exception")
     @patch("threading.Thread.start", new=lambda x: None)
     def test_successful_compilation(self, mock_logger, mock_open):


### PR DESCRIPTION
The CentML platform compilation image will want to call `hidet_backend_server` from `server_compilation.py`. However, it will not want to save the compiled model locally but instead to s3. 