### PR TITLE
Generate hash using torch.save instead of hidet

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
+        pip install hidet
         pip install .
     - name: Test with pytest
       run: |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Inside the project's base directory, run the following commands:
 pip install . 
 ```
 
+To use the compilation feature, make sure to install Hidet:
+```bash
+pip install hidet
+```
+
 ### Tests
 To run tests, first install required packages:
 ```bash

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -64,7 +64,7 @@ class Runner:
         sha_hash = hashlib.sha256()
         with open(self.serialized_model_path, "rb") as serialized_model_file:
             # Read in chunks to not load too much into memory
-            for block in iter(lambda: serialized_model_file.read(4096), b""):
+            for block in iter(lambda: serialized_model_file.read(config_instance.HASH_CHUNK_SIZE), b""):
                 sha_hash.update(block)
 
         return sha_hash.hexdigest()

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -58,7 +58,7 @@ class Runner:
         sha_hash = hashlib.sha256()
 
         # The GraphModule can be large, so lets serialize it to disk
-        torch.save(self.module, self.serialized_model_path, pickle_protocol=4)
+        torch.save(self.module, self.serialized_model_path, pickle_protocol=config_instance.PICKLE_PROTOCOL)
 
         with open(self.serialized_model_path, "rb") as serialized_model_file:
             # Read in chunks to not load too much into memory
@@ -88,7 +88,7 @@ class Runner:
         with open(self.serialized_model_path, 'rb') as model_file:
             # Inputs should not be too large, so we can serialize it in memory
             serialized_inputs = io.BytesIO()
-            torch.save(self.inputs, serialized_inputs, pickle_protocol=4)
+            torch.save(self.inputs, serialized_inputs, pickle_protocol=config_instance.PICKLE_PROTOCOL)
 
             compile_response = requests.post(
                 url=f"{config_instance.SERVER_URL}/submit/{model_id}",

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -55,10 +55,11 @@ class Runner:
         self._inputs = None
 
     def __del__(self):
+        
         if os.path.exists(self.serialized_model_dir):
             shutil.rmtree(self.serialized_model_dir)
 
-    def _get_model_id(self) -> str:        
+    def _get_model_id(self) -> str:
         # The GraphModule can be large, so lets serialize it to disk
         # This saves a zip file full of pickled files.
         try:
@@ -95,7 +96,7 @@ class Runner:
         # Inputs should not be too large, so we can serialize them in memory
         serialized_inputs = io.BytesIO()
         torch.save(self.inputs, serialized_inputs, pickle_protocol=config_instance.PICKLE_PROTOCOL)
-        serialized_inputs.seek(0) # seek since serialized_inputs is still in memory
+        serialized_inputs.seek(0)  # seek since serialized_inputs is still in memory
 
         with open(self.seralized_model_path, 'rb') as model_file:
             compile_response = requests.post(

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -52,6 +52,7 @@ class Runner:
         self._inputs = None
 
     def _get_model_id(self) -> str:
+
         # We use to_folder to save the GraphModule's:
         # - state dict (weights and more) in pickled form (using torch.save)
         # - submodules (layers, activation functions, etc.), usally as pickled files 
@@ -89,7 +90,10 @@ class Runner:
 
             # Hash the metadata since it's not saved with to_folder
             if self.module.meta:
-                json_metadata: str = json.dumps(self.module.meta, sort_keys=True)
+                try:
+                    json_metadata: str = json.dumps(self.module.meta, sort_keys=True)
+                except Exception as e:
+                    raise Exception(f"Failed to hash metadata: {e}")
                 sha_hash.update(json_metadata.encode())
 
         return sha_hash.hexdigest()
@@ -149,7 +153,6 @@ class Runner:
 
     def remote_compilation(self):
         model_id = self._get_model_id()
-        print(model_id)
 
         # check if compiled forward is saved locally
         compiled_forward_path = get_backend_compiled_forward_path(model_id)

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -53,7 +53,7 @@ class Runner:
         # We use to_folder to save the GraphModule's:
         # - state dict (weights and more) in pickled form (using torch.save)
         # - submodules (layers, activation functions, etc.), usally as pickled files
-        # - parameters and buffers (in the state dict)
+        # - parameters and buffers (shape + type in module.py, data in the state dict)
         # the GraphModule's Graph is not saved since the code generated from it is
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -91,14 +91,6 @@ class Runner:
                         # Read in chunks to avoid loading too much into memory
                         for block in iter(lambda: f.read(4096), b""):
                             sha_hash.update(block)
-
-            # Hash the metadata since it's not saved with to_folder
-            if self.module.meta:
-                try:
-                    json_metadata: str = json.dumps(self.module.meta, sort_keys=True)
-                except Exception as e:
-                    raise Exception(f"Failed to dump metadata to json: {e}") from e
-                sha_hash.update(json_metadata.encode())
 
         return sha_hash.hexdigest()
 

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -11,7 +11,6 @@ from typing import List, Callable
 import requests
 from torch.fx import GraphModule
 import torch
-from hidet.runtime.compiled_graph import CompiledGraph
 from centml.compiler.config import config_instance, CompilationStatus
 from centml.compiler.utils import get_backend_compiled_forward_path
 
@@ -77,7 +76,7 @@ class Runner:
 
         return sha_hash.hexdigest()
 
-    def _download_model(self, model_id: str) -> CompiledGraph:
+    def _download_model(self, model_id: str):
         download_response = requests.get(
             url=f"{config_instance.SERVER_URL}/download/{model_id}", timeout=config_instance.TIMEOUT
         )

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -95,12 +95,12 @@ class Runner:
         # Inputs should not be too large, so we can serialize them in memory
         serialized_inputs = io.BytesIO()
         torch.save(self.inputs, serialized_inputs, pickle_protocol=config_instance.PICKLE_PROTOCOL)
-        serialized_inputs_content = serialized_inputs.getvalue()
+        serialized_inputs.seek(0) # seek since serialized_inputs is still in memory
 
         with open(self.seralized_model_path, 'rb') as model_file:
             compile_response = requests.post(
                 url=f"{config_instance.SERVER_URL}/submit/{model_id}",
-                files={"model": model_file, "inputs": serialized_inputs_content},
+                files={"model": model_file, "inputs": serialized_inputs},
                 timeout=config_instance.TIMEOUT,
             )
 

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -24,5 +24,7 @@ class Config:
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
+    SERIALIZED_MODEL_PATH = "/tmp/centml_serialized_model.pkl" 
+
 
 config_instance = Config()

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -26,8 +26,8 @@ class Config:
 
     # Use a constant path since torch.save uses the given file name in it's zipfile.
     # Thus, a different path would result in a different hash.
-    SERIALIZED_MODEL_FILE = "serialized_model.pkl"
-    SERIALIZED_INPUT_FILE = "serialized_input.pkl"
+    SERIALIZED_MODEL_FILE = "serialized_model.zip"
+    SERIALIZED_INPUT_FILE = "serialized_input.zip"
     PICKLE_PROTOCOL = 4
 
 

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -26,7 +26,7 @@ class Config:
 
     # Use a constant path since torch.save uses the given file name in it's zipfile.
     # Thus, a different path would result in a different hash.
-    SERIALIZED_MODEL_PATH = "/tmp/centml_serialized_model.pkl"
+    SERIALIZED_MODEL_FILE = "centml_serialized_model.pkl"
     PICKLE_PROTOCOL = 4
 
 

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -26,7 +26,8 @@ class Config:
 
     # Use a constant path since torch.save uses the given file name in it's zipfile.
     # Thus, a different path would result in a different hash.
-    SERIALIZED_MODEL_FILE = "centml_serialized_model.pkl"
+    SERIALIZED_MODEL_FILE = "serialized_model.pkl"
+    SERIALIZED_INPUT_FILE = "serialized_input.pkl"
     PICKLE_PROTOCOL = 4
 
 

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -24,6 +24,8 @@ class Config:
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
+    # Use a constant path since torch.save uses the given file name in it's zipfile.
+    # Thus, a different path would result in a different hash.
     SERIALIZED_MODEL_PATH = "/tmp/centml_serialized_model.pkl"
     PICKLE_PROTOCOL = 4
 

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -25,10 +25,12 @@ class Config:
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
     # Use a constant path since torch.save uses the given file name in it's zipfile.
-    # Thus, a different path would result in a different hash.
+    # Thus, a different filename would result in a different hash.
     SERIALIZED_MODEL_FILE = "serialized_model.zip"
     SERIALIZED_INPUT_FILE = "serialized_input.zip"
     PICKLE_PROTOCOL = 4
+
+    HASH_CHUNK_SIZE = 4096
 
 
 config_instance = Config()

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -24,7 +24,8 @@ class Config:
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH = os.path.join(CACHE_PATH, "server")
 
-    SERIALIZED_MODEL_PATH = "/tmp/centml_serialized_model.pkl" 
+    SERIALIZED_MODEL_PATH = "/tmp/centml_serialized_model.pkl"
+    PICKLE_PROTOCOL = 4
 
 
 config_instance = Config()

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -1,8 +1,5 @@
 import os
 from enum import Enum
-import hidet
-
-hidet.option.imperative(False)
 
 
 class CompilationStatus(Enum):
@@ -18,7 +15,7 @@ class Config:
 
     CACHE_PATH = os.getenv("CENTML_CACHE_DIR", default=os.path.expanduser("~/.cache/centml"))
     SERVER_IP = os.getenv("CENTML_SERVER_IP", default="0.0.0.0")
-    SERVER_PORT = os.getenv("CENTML_SERVER_PORT", default="8080")
+    SERVER_PORT = os.getenv("CENTML_SERVER_PORT", default="8090")
     SERVER_URL = f"http://{SERVER_IP}:{SERVER_PORT}"
 
     BACKEND_BASE_PATH = os.path.join(CACHE_PATH, "backend")

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -67,7 +67,6 @@ def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):
     try:
         tfx_graph = torch.load(tfx_contents)
         example_inputs = torch.load(ei_contents)
-        print("HERE")
     except Exception as e:
         dir_cleanup(model_id)
         raise HTTPException(

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -1,6 +1,5 @@
 import io
 import os
-import pickle
 from http import HTTPStatus
 import logging
 import uvicorn
@@ -46,7 +45,7 @@ def background_compile(model_id: str, tfx_graph, example_inputs):
     try:
         save_path = get_server_compiled_forward_path(model_id)
         with open(save_path, "wb") as f:
-            pickle.dump(compiled_graph_module, f)
+            torch.save(compiled_graph_module, f, pickle_protocol=config_instance.PICKLE_PROTOCOL)
     except Exception as e:
         raise Exception(f"Saving graph module failed: {e}") from e
 
@@ -58,7 +57,7 @@ def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):
     except Exception as e:
         dir_cleanup(model_id)
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=f"Compilation: error reading serialized content. {e}"
+            status_code=HTTPStatus.BAD_REQUEST, detail=f"Compilation: error reading serialized content: {e}"
         ) from e
     finally:
         model.file.close()
@@ -70,7 +69,7 @@ def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):
     except Exception as e:
         dir_cleanup(model_id)
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=f"Compilation: error loading pickled content. {e}"
+            status_code=HTTPStatus.BAD_REQUEST, detail=f"Compilation: error loading content with torch.load: {e}"
         ) from e
 
     return tfx_graph, example_inputs

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -44,8 +44,7 @@ def background_compile(model_id: str, tfx_graph, example_inputs):
 
     try:
         save_path = get_server_compiled_forward_path(model_id)
-        with open(save_path, "wb") as f:
-            torch.save(compiled_graph_module, f, pickle_protocol=config_instance.PICKLE_PROTOCOL)
+        torch.save(compiled_graph_module, save_path, pickle_protocol=config_instance.PICKLE_PROTOCOL)
     except Exception as e:
         raise Exception(f"Saving graph module failed: {e}") from e
 

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -46,7 +46,7 @@ def background_compile(model_id: str, tfx_graph, example_inputs):
         save_path = get_server_compiled_forward_path(model_id)
         torch.save(compiled_graph_module, save_path, pickle_protocol=config_instance.PICKLE_PROTOCOL)
     except Exception as e:
-        raise Exception(f"Saving graph module failed: {e}") from e
+        logging.getLogger(__name__).exception(f"Saving graph module failed: {e}")
 
 
 def read_upload_files(model_id: str, model: UploadFile, inputs: UploadFile):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ python-multipart>=0.0.6
 Requests==2.31.0
 tabulate>=0.9.0
 pyjwt>=2.8.0
-hidet>=0.3.1
 platform_api_client @ git+https://github.com/CentML/platform_api_python_client.git@main

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -5,7 +5,6 @@ from unittest.mock import patch, MagicMock
 import torch
 from parameterized import parameterized_class
 from torch.fx import GraphModule
-import hidet
 from centml.compiler.backend import Runner
 from centml.compiler.config import CompilationStatus, config_instance
 from .test_helpers import MODEL_SUITE

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -32,7 +32,7 @@ class TestGetModelId(SetUpGraphModule):
     @patch('hidet.save_graph')
     def test_none_flow_graph(self, mock_save_graph):
         with self.assertRaises(Exception) as context:
-            self.runner._get_model_id(None)
+            self.runner._get_model_id()
 
         self.assertIn("Getting model id: flow graph is None.", str(context.exception))
         mock_save_graph.assert_not_called()
@@ -43,7 +43,7 @@ class TestGetModelId(SetUpGraphModule):
         flowgraph = MagicMock(spec=hidet.FlowGraph)
 
         with self.assertRaises(Exception) as context:
-            self.runner._get_model_id(flowgraph)
+            self.runner._get_model_id()
 
         self.assertIn("Getting model id: failed to save FlowGraph.", str(context.exception))
         mock_save_graph.assert_called_once()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -55,9 +55,9 @@ class TestGetModelId(SetUpGraphModule):
         model_compiled_2 = torch.compile(self.model, backend="centml")
         model_compiled_2(self.inputs)
         hash_2 = mock_wait.call_args[0][0]
+        torch._dynamo.reset()
 
         self.assertEqual(hash_1, hash_2)
-        torch._dynamo.reset()
 
     # Given two different models, the model ids should be different
     # We made the models different by adding 1 to the first value in some layer's

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import torch
 from transformers import BertForPreTraining, AutoTokenizer
 
@@ -13,3 +14,12 @@ MODEL_SUITE = {
         )['input_ids'],
     },
 }
+
+
+def get_dummy_model_and_inputs(model_content, input_content):
+    model, inputs = BytesIO(), BytesIO()
+    torch.save(model_content, model)
+    torch.save(input_content, inputs)
+    model.seek(0)
+    inputs.seek(0)
+    return model, inputs

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,5 @@
-import pickle
+import shutil
+import tempfile
 import warnings
 from io import BytesIO
 from unittest import TestCase
@@ -11,8 +12,8 @@ from fastapi import UploadFile, HTTPException
 from fastapi.testclient import TestClient
 from parameterized import parameterized_class
 from centml.compiler.server import app, background_compile, read_upload_files
-from centml.compiler.config import CompilationStatus
-from .test_helpers import MODEL_SUITE
+from centml.compiler.config import CompilationStatus, config_instance
+from tests.test_helpers import MODEL_SUITE
 
 client = TestClient(app=app)
 
@@ -45,33 +46,37 @@ class TestStatusHandler(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": CompilationStatus.DONE.value})
 
-
 @parameterized_class(list(MODEL_SUITE.values()))
 class TestBackgroundCompile(TestCase):
     @pytest.mark.gpu
-    @patch("centml.compiler.server.open")
     @patch("logging.Logger.exception")
+    @patch("centml.compiler.server.torch.save")
     @patch("threading.Thread.start", new=lambda x: None)
-    def test_successful_compilation(self, mock_logger, mock_open):
+    def test_successful_compilation(self, mock_save, mock_logger):
         # For some reason there is a deadlock with parallel builds
         hidet.option.parallel_build(False)
         warnings.filterwarnings("ignore", category=UserWarning)
 
         model = self.model.cuda()
         inputs = self.inputs.cuda()
+        
+        # Get the graph_module and example inputs that would be passed to background compile
+        def mock_init(self, module, inputs):
+            # set this so Runner.__del__ doesn't throw an exception
+            self.serialized_model_dir = "fake_path"
+            global graph_module
+            global example_inputs
+            graph_module, example_inputs = module, inputs
 
-        with patch('centml.compiler.backend.Runner.__init__', return_value=None) as mock_init, patch(
-            'centml.compiler.backend.Runner.__call__', new=model.forward
-        ):
+        with patch('centml.compiler.backend.Runner.__init__', new=mock_init), \
+        patch('centml.compiler.backend.Runner.__call__', new=model.forward):
             model_compiled = torch.compile(model, backend="centml")
             model_compiled(inputs)
-            graph_module = mock_init.call_args[0][0]
-            example_inputs = mock_init.call_args[0][1]
 
         model_id = "successful_model"
         background_compile(model_id, graph_module, example_inputs)
 
-        mock_open.assert_called_once()
+        mock_save.assert_called_once()
         mock_logger.assert_not_called()
 
 
@@ -88,16 +93,16 @@ class TestReadUploadFiles(TestCase):
         self.assertEqual(excinfo.exception.status_code, HTTPStatus.BAD_REQUEST)
         self.assertIn("Compilation: error reading serialized content", str(excinfo.exception))
 
-    @patch("pickle.loads", side_effect=Exception("an exception occurred"))
-    def test_cant_unpickle(self, mock_pickle_loads):
+    @patch("torch.load", side_effect=Exception("an exception occurred"))
+    def test_cant_load(self, mock_load):
         model_id = "file_cant_be_unpickled"
 
-        model_data = "model"
-        inputs_data = "inputs"
-
-        # Create file-like objects with any data
-        model_file = BytesIO(pickle.dumps(model_data))
-        inputs_file = BytesIO(pickle.dumps(inputs_data))
+        # Create file-like objects with test data
+        model_file, inputs_file = BytesIO(), BytesIO()
+        torch.save("model", model_file)
+        torch.save("inputs", inputs_file)
+        model_file.seek(0)
+        inputs_file.seek(0)
 
         model = UploadFile(filename="model", file=model_file)
         inputs = UploadFile(filename="inputs", file=inputs_file)
@@ -105,19 +110,21 @@ class TestReadUploadFiles(TestCase):
         with self.assertRaises(HTTPException) as excinfo:
             read_upload_files(model_id, model, inputs)
 
-        mock_pickle_loads.assert_called_once()
+        mock_load.assert_called_once()
         self.assertEqual(excinfo.exception.status_code, HTTPStatus.BAD_REQUEST)
-        self.assertIn("error loading pickled content", str(excinfo.exception))
+        self.assertIn("Compilation: error loading content with torch.load:", str(excinfo.exception))
 
     def test_proper_read(self):
         model_id = "test_model_id"
 
-        # Create file-like objects with pickleable data
-        model_data = "model"
-        inputs_data = "inputs"
+        model_data, inputs_data = "model", "inputs"
 
-        model_file = BytesIO(pickle.dumps(model_data))
-        inputs_file = BytesIO(pickle.dumps(inputs_data))
+        # Create file-like objects with test data
+        model_file, inputs_file = BytesIO(), BytesIO()
+        torch.save(model_data, model_file)
+        torch.save(inputs_data, inputs_file)
+        model_file.seek(0)
+        inputs_file.seek(0)
 
         model = UploadFile(filename="model", file=model_file)
         inputs = UploadFile(filename="inputs", file=inputs_file)
@@ -130,21 +137,28 @@ class TestReadUploadFiles(TestCase):
 
 class TestCompileHandler(TestCase):
     def setUp(self) -> None:
-        self.model = pickle.dumps("model")
-        self.inputs = pickle.dumps("inputs")
+        self.model = BytesIO()
+        self.inputs = BytesIO()
+        torch.save("model", self.model)
+        torch.save("inputs", self.inputs)
+        self.model.seek(0)
+        self.inputs.seek(0)
 
-    @patch("os.path.isdir", new=lambda x: True)
-    def test_model_compiling(self):
+    @patch("centml.compiler.server.get_status")
+    def test_model_compiling(self, mock_status):
         model_id = "compiling_model"
+        mock_status.return_value = CompilationStatus.COMPILING
 
         response = client.post(f"/submit/{model_id}", files={"model": self.model, "inputs": self.inputs})
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @patch("os.makedirs")
     @patch("centml.compiler.server.background_compile")
-    @patch("os.path.isdir", new=lambda x: False)
-    def test_model_not_compiled(self, mock_compile, mock_mkdir):
+    @patch("centml.compiler.server.get_status")
+    def test_model_not_compiled(self, mock_status, mock_compile, mock_mkdir):
         model_id = "compiling_model"
+        mock_status.return_value = CompilationStatus.NOT_FOUND
+        # Stop compilation from happening
         mock_compile.new = lambda x, y, z: None
 
         response = client.post(f"/submit/{model_id}", files={"model": self.model, "inputs": self.inputs})
@@ -171,3 +185,7 @@ class TestDownloadHandler(TestCase):
         response = client.get(f"/download/{model_id}")
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+# if __name__ == "__main__":
+#     t = TestBackgroundCompile_0()
+#     t.test_successful_compilation()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,3 @@
-import shutil
-import tempfile
 import warnings
 from io import BytesIO
 from unittest import TestCase
@@ -185,7 +183,3 @@ class TestDownloadHandler(TestCase):
         response = client.get(f"/download/{model_id}")
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
-
-# if __name__ == "__main__":
-#     t = TestBackgroundCompile_0()
-#     t.test_successful_compilation()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,7 +64,7 @@ class TestBackgroundCompile(TestCase):
                 return module.forward
 
         mock_init = MockRunner()
-        
+
         # self.model and self.inputs come from @parameterized_class
         model, inputs = self.model.cuda(), self.inputs.cuda()
         model_compiled = torch.compile(model, backend=mock_init)
@@ -75,6 +75,7 @@ class TestBackgroundCompile(TestCase):
 
         mock_save.assert_called_once()
         mock_logger.assert_not_called()
+
 
 class TestReadUploadFiles(TestCase):
     def test_mock_cant_read(self):


### PR DESCRIPTION
torch.save can generate a consistent hash.

I also replace direct pickling of the model with torch.save and torch.load to avoid repeated serialization