### PR TITLE
Bug: ensure serialized model file isn't empty when checking status

### DIFF
--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -84,6 +84,8 @@ class Runner:
             raise Exception(
                 f"Download: request failed, exception from server:\n{download_response.json().get('detail')}"
             )
+        if download_response.content == b"":
+            raise Exception("Download: empty response from server")
         download_path = get_backend_compiled_forward_path(model_id)
         with open(download_path, "wb") as f:
             f.write(download_response.content)

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -43,8 +43,9 @@ def background_compile(model_id: str, tfx_graph, example_inputs):
         dir_cleanup(model_id)
 
     try:
-        # torch.save creates an empty zip file then saves the data in multiple calls.
-        # We don't want this incomplete zipfile to be mistaken for the serialized forward function.
+        # torch.save's writing is not atomic; it creates an empty zip file then saves the data in multiple calls.
+        # We don't want this incomplete zipfile to be mistaken for the serialized forward function by /status/.
+        # To avoid this, we write to a tmp file and rename it to the correct path after saving.
         save_path = get_server_compiled_forward_path(model_id)
         tmp_path = save_path + ".tmp"
         torch.save(compiled_graph_module, tmp_path, pickle_protocol=config_instance.PICKLE_PROTOCOL)

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -20,7 +20,10 @@ def get_status(model_id: str):
     if not os.path.isdir(os.path.join(config_instance.SERVER_BASE_PATH, model_id)):
         return CompilationStatus.NOT_FOUND
 
-    if not os.path.isfile(get_server_compiled_forward_path(model_id)):
+    # For the case where size == 0, torch.save creates a zip file before saving the actual data.
+    # We don't want this empty zipfile to be considered the serialized forward function
+    save_path = get_server_compiled_forward_path(model_id)
+    if not os.path.isfile(save_path) or os.path.getsize(save_path) == 0:
         return CompilationStatus.COMPILING
 
     return CompilationStatus.DONE

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,7 @@ class TestStatusHandler(TestCase):
 
     @patch("os.path.isfile", new=lambda x: False)
     @patch("os.path.isdir", new=lambda x: True)
+    @patch("os.path.getsize", new=lambda x: 1024)
     def test_model_compiling(self):
         model_id = "compiling_model"
         response = client.get(f"/status/{model_id}")
@@ -36,6 +37,16 @@ class TestStatusHandler(TestCase):
 
     @patch("os.path.isfile", new=lambda x: True)
     @patch("os.path.isdir", new=lambda x: True)
+    @patch("os.path.getsize", new=lambda x: 0)
+    def test_empty_file(self):
+        model_id = "empty_model"
+        response = client.get(f"/status/{model_id}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json(), {"status": CompilationStatus.COMPILING.value})
+
+    @patch("os.path.isfile", new=lambda x: True)
+    @patch("os.path.isdir", new=lambda x: True)
+    @patch("os.path.getsize", new=lambda x: 1024)
     def test_model_done(self):
         model_id = "completed_model"
         response = client.get(f"/status/{model_id}")


### PR DESCRIPTION
Because we now use torch.save instead of pickle.dump to serialize the model, a bug arose.

torch.save first creates a zip file, and then dumps the pickled representation of the model to that zipfile.

However, if the client requested the status of the model after the zipfile creation but before dumping the pickled content, the status endpoint would return `DONE` since it treated the empty zip file as the serialized model. It would then send an empty file to the client.

Therefore, if the file is empty, we should say it's still compiling.