### PR TITLE
use CENTML_SERVER_URL instead of IP and PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run the server locally, you can use the following CLI command:
 centml server
 ```
 By default, the server will run at the URL `http://0.0.0.0:8090`. \
-You can change this by setting the environment variables `CENTML_SERVER_IP` and `CENTML_SERVER_PORT`
+You can change this by setting the environment variable `CENTML_SERVER_URL`
 
 
 Then, within your python script include the following:
@@ -55,7 +55,7 @@ output = compiled_model(inputs)
 ```
 Note that the centml backend compiler is non-blocking. This means it that until the server returns the compiled model, your python script will use the uncompiled model to generate the output.
 
-Again, make sure your script's environment sets the environment variables `CENTML_SERVER_IP` and `CENTML_SERVER_PORT` to communicate with the desired server.
+Again, make sure your script's environment sets `CENTML_SERVER_URL` to communicate with the desired server.
 
 
 ### Tests

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -1,6 +1,5 @@
 import os
 from enum import Enum
-from urllib.parse import urlparse
 
 
 class CompilationStatus(Enum):
@@ -17,9 +16,6 @@ class Config:
     CACHE_PATH: str = os.getenv("CENTML_CACHE_DIR", default=os.path.expanduser("~/.cache/centml"))
 
     SERVER_URL: str = os.getenv("CENTML_SERVER_URL", default="http://0.0.0.0:8090")
-    SERVER_IP: str
-    SERVER_PORT: str
-    SERVER_IP, SERVER_PORT = str(urlparse(SERVER_URL).hostname), str(urlparse(SERVER_URL).port)
 
     BACKEND_BASE_PATH: str = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH: str = os.path.join(CACHE_PATH, "server")

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -2,6 +2,7 @@ import os
 from enum import Enum
 from urllib.parse import urlparse
 
+
 class CompilationStatus(Enum):
     NOT_FOUND = "NOT_FOUND"
     COMPILING = "COMPILING"
@@ -17,8 +18,8 @@ class Config:
 
     SERVER_URL: str = os.getenv("CENTML_SERVER_URL", default="http://0.0.0.0:8090")
     SERVER_IP: str
-    SERVER_PORT: str 
-    SERVER_IP, SERVER_PORT = urlparse(SERVER_URL).hostname, urlparse(SERVER_URL).port
+    SERVER_PORT: str
+    SERVER_IP, SERVER_PORT = str(urlparse(SERVER_URL).hostname), str(urlparse(SERVER_URL).port)
 
     BACKEND_BASE_PATH: str = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH: str = os.path.join(CACHE_PATH, "server")

--- a/centml/compiler/config.py
+++ b/centml/compiler/config.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-
+from urllib.parse import urlparse
 
 class CompilationStatus(Enum):
     NOT_FOUND = "NOT_FOUND"
@@ -14,9 +14,11 @@ class Config:
     COMPILING_SLEEP_TIME: int = 15
 
     CACHE_PATH: str = os.getenv("CENTML_CACHE_DIR", default=os.path.expanduser("~/.cache/centml"))
-    SERVER_IP: str = os.getenv("CENTML_SERVER_IP", default="0.0.0.0")
-    SERVER_PORT: str = os.getenv("CENTML_SERVER_PORT", default="8090")
-    SERVER_URL: str = f"http://{SERVER_IP}:{SERVER_PORT}"
+
+    SERVER_URL: str = os.getenv("CENTML_SERVER_URL", default="http://0.0.0.0:8090")
+    SERVER_IP: str
+    SERVER_PORT: str 
+    SERVER_IP, SERVER_PORT = urlparse(SERVER_URL).hostname, urlparse(SERVER_URL).port
 
     BACKEND_BASE_PATH: str = os.path.join(CACHE_PATH, "backend")
     SERVER_BASE_PATH: str = os.path.join(CACHE_PATH, "server")

--- a/centml/compiler/server.py
+++ b/centml/compiler/server.py
@@ -1,6 +1,7 @@
 import io
 import os
 from http import HTTPStatus
+from urllib.parse import urlparse
 import logging
 import uvicorn
 import torch
@@ -107,7 +108,8 @@ async def download_handler(model_id: str):
 
 
 def run():
-    uvicorn.run(app, host=config_instance.SERVER_IP, port=int(config_instance.SERVER_PORT))
+    parsed = urlparse(config_instance.SERVER_URL)
+    uvicorn.run(app, host=parsed.hostname, port=parsed.port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Platform's RC jobs is configured to talk to proxy using a single env variable named `CENTML_PROXY_URL`. I wanted to make the python client consistent with this