### PR TITLE
create_inference bug fix

### DIFF
--- a/centml/sdk/api.py
+++ b/centml/sdk/api.py
@@ -47,7 +47,7 @@ def get_compute(id):
 
 def create_inference(
     name, image, port, is_private, hw_to_id_map, health, min_replicas, max_replicas, env, command, command_args, timeout
-):  
+):
     triplet = None
     if is_private:
         triplet = client_certs.generate_ca_client_triplet(name)

--- a/centml/sdk/api.py
+++ b/centml/sdk/api.py
@@ -47,7 +47,8 @@ def get_compute(id):
 
 def create_inference(
     name, image, port, is_private, hw_to_id_map, health, min_replicas, max_replicas, env, command, command_args, timeout
-):
+):  
+    triplet = None
     if is_private:
         triplet = client_certs.generate_ca_client_triplet(name)
         # Handle automatic download of client private secrets


### PR DESCRIPTION
calling `sdk.api.create_inference` with is_private=False will raise `local variable 'triplet' referenced before assignment` since `triplet` does not get defined 