### PR TITLE
compiler self.module deletion bug fix

### DIFF
--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -164,7 +164,8 @@ class Runner:
         # Let garbage collector free the memory used by the uncompiled model
         with self.lock:
             del self.inputs
-            del self.module
+            if self.module:
+                del self.module
             gc.collect()
             torch.cuda.empty_cache()
 


### PR DESCRIPTION
Within the runner class, self.module is kept as a weakref. We do this to be able to delete the uncompiled model form the GPU when we have the compiled model. 

However something interesting can happen if a user's compilation script finishes before compilation is completed. The user script will wait until compilation is done. However, if it's been a while since a non-compiled inference call was made, python's garbage collector will see that there are no strong references to self.module, and it will thus delete the object.

So, when compilation does finish and it calls `del self.module` to delete the uncompiled module, it tries to access something that doesn't exist and throws an error. This PR will prevent this bad access

NOTE: The behaviour of not exiting an inference script because compilation is done is something we want to avoid: [see this issue](https://github.com/CentML/centml-python-client/issues/58)

