### PR TITLE
Better exception catching

### DIFF
--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -12,7 +12,7 @@ import requests
 import torch
 from torch.fx import GraphModule
 from centml.compiler.config import settings, CompilationStatus
-from centml.compiler.utils import get_backend_compiled_forward_path, verify_model_and_input_paths
+from centml.compiler.utils import get_backend_compiled_forward_path
 
 
 class Runner:
@@ -95,7 +95,12 @@ class Runner:
 
     def _compile_model(self, model_id: str):
         # The model should have been saved using torch.save when we found the model_id
-        verify_model_and_input_paths(self.serialized_model_path, self.serialized_input_path)
+        if not self.serialized_model_path or not self.serialized_input_path:
+            raise Exception("Model or inputs not serialized")
+        if not os.path.isfile(self.serialized_model_path):
+            raise Exception(f"Model not saved at path {self.serialized_model_path}")
+        if not os.path.isfile(self.serialized_input_path):
+            raise Exception(f"Inputs not saved at path {self.serialized_input_path}")
 
         with open(self.serialized_model_path, 'rb') as model_file, open(self.serialized_input_path, 'rb') as input_file:
             compile_response = requests.post(

--- a/centml/compiler/backend.py
+++ b/centml/compiler/backend.py
@@ -12,10 +12,7 @@ import requests
 import torch
 from torch.fx import GraphModule
 from centml.compiler.config import settings, CompilationStatus
-from centml.compiler.utils import (
-    get_backend_compiled_forward_path, 
-    verify_model_and_input_paths,
-)
+from centml.compiler.utils import get_backend_compiled_forward_path, verify_model_and_input_paths
 
 
 class Runner:
@@ -117,7 +114,9 @@ class Runner:
             # get server compilation status
             status = None
             try:
-                status_response = requests.get(f"{settings.CENTML_SERVER_URL}/status/{model_id}", timeout=settings.TIMEOUT)
+                status_response = requests.get(
+                    f"{settings.CENTML_SERVER_URL}/status/{model_id}", timeout=settings.TIMEOUT
+                )
                 if status_response.status_code != HTTPStatus.OK:
                     raise Exception(
                         f"Status check: request failed, exception from server:\n{status_response.json().get('detail')}"
@@ -140,7 +139,7 @@ class Runner:
             else:
                 tries += 1
 
-            if tries >= settings.MAX_RETRIES:
+            if tries > settings.MAX_RETRIES:
                 raise Exception("Waiting for status: compilation failed too many times.\n")
 
             time.sleep(settings.COMPILING_SLEEP_TIME)

--- a/centml/compiler/utils.py
+++ b/centml/compiler/utils.py
@@ -26,12 +26,3 @@ def dir_cleanup(model_id: str):
         shutil.rmtree(dir_path)
     except Exception as e:
         raise Exception("Failed to delete the directory") from e
-
-
-def verify_model_and_input_paths(model_path, input_path):
-    if not model_path or not input_path:
-        raise Exception("Model or inputs not serialized")
-    if not os.path.isfile(model_path):
-        raise Exception(f"Model not saved at path {model_path}")
-    if not os.path.isfile(input_path):
-        raise Exception(f"Inputs not saved at path {input_path}")

--- a/centml/compiler/utils.py
+++ b/centml/compiler/utils.py
@@ -26,3 +26,11 @@ def dir_cleanup(model_id: str):
         shutil.rmtree(dir_path)
     except Exception as e:
         raise Exception("Failed to delete the directory") from e
+
+def verify_model_and_input_paths(model_path, input_path):
+    if not model_path or not input_path:
+        raise Exception("Model or inputs not serialized")
+    if not os.path.isfile(model_path):
+        raise Exception(f"Model not saved at path {model_path}")
+    if not os.path.isfile(input_path):
+        raise Exception(f"Inputs not saved at path {input_path}")

--- a/centml/compiler/utils.py
+++ b/centml/compiler/utils.py
@@ -27,6 +27,7 @@ def dir_cleanup(model_id: str):
     except Exception as e:
         raise Exception("Failed to delete the directory") from e
 
+
 def verify_model_and_input_paths(model_path, input_path):
     if not model_path or not input_path:
         raise Exception("Model or inputs not serialized")


### PR DESCRIPTION
Previously, if the call to submit for compilation or to check the model status would fail, then the compilation thread would crash. I added try catch blocks to catch this while still logging the raised errors.

I also added a unit test to cover the case where the call to compilation or status fails.

I also realized that the try catch block around the child thread creation call wasn't actually catching exceptions that happen in the thread, just any exceptions that happen when you create the thread. Since this means that an exception in the child thread won't case the main inference thread to crash, I don't know if we actually need to catch it, but I fixed this to catch exceptions as expected