### PR TITLE
[CLI] fix credential file format

### DIFF
--- a/centml/sdk/auth.py
+++ b/centml/sdk/auth.py
@@ -28,7 +28,7 @@ def store_centml_cred(token_file):
     try:
         with open(token_file, 'r') as f:
             os.makedirs(settings.CENTML_CONFIG_PATH, exist_ok=True)
-            refresh_token = json.load(f)["refreshToken"]
+            refresh_token = json.load(f)["refresh_token"]
 
             refresh_centml_token(refresh_token)
     except Exception:
@@ -51,12 +51,12 @@ def get_centml_token():
     if not cred:
         sys.exit("CentML credentials not found. Please login...")
 
-    exp_time = int(jwt.decode(cred["idToken"], options={"verify_signature": False})["exp"])
+    exp_time = int(jwt.decode(cred["id_token"], options={"verify_signature": False})["exp"])
 
     if time.time() >= exp_time - 100:
-        cred = refresh_centml_token(cred["refreshToken"])
+        cred = refresh_centml_token(cred["refresh_token"])
 
-    return cred["idToken"]
+    return cred["id_token"]
 
 
 def remove_centml_cred():

--- a/centml/sdk/config.py
+++ b/centml/sdk/config.py
@@ -1,8 +1,13 @@
 import os
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pathlib import Path
 
 
 class Config(BaseSettings):
+
+    # It is possible to override the default values by setting the environment variables
+    model_config = SettingsConfigDict(env_file=Path('.env'))
+
     CENTML_WEB_URL: str = "https://app.centml.com/"
     CENTML_CONFIG_PATH: str = os.path.expanduser("~/.centml")
     CENTML_CRED_FILE: str = "credentials.json"

--- a/centml/sdk/config.py
+++ b/centml/sdk/config.py
@@ -1,6 +1,6 @@
 import os
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Config(BaseSettings):


### PR DESCRIPTION
Credential format CentML platform provides has been changed to match Google's.  I also added support for local .env files for testing. 