### PR TITLE
feat(sdk): support inference_v3 config_file mount

### DIFF
--- a/centml/sdk/utils/config_file.py
+++ b/centml/sdk/utils/config_file.py
@@ -9,6 +9,8 @@ from platform_api_python_client import ConfigFileMount
 # Field-level validation (size cap, filename charset, mount_path rules) is
 # left to the API so SDK doesn't drift when server limits change.
 def load_config_file_mount(path: str, mount_path: str, filename: Optional[str] = None) -> ConfigFileMount:
-    with open(path, "r", encoding="utf-8") as f:
+    # newline="" disables universal-newline translation so CRLF/CR line
+    # endings reach the server byte-faithful instead of being normalized to \n.
+    with open(path, "r", encoding="utf-8", newline="") as f:
         content = f.read()
     return ConfigFileMount(filename=filename or os.path.basename(path), mount_path=mount_path, content=content)

--- a/centml/sdk/utils/config_file.py
+++ b/centml/sdk/utils/config_file.py
@@ -1,0 +1,13 @@
+import os
+from typing import Optional
+
+from platform_api_python_client import ConfigFileMount
+
+
+# Load a file off disk into a ConfigFileMount. Field-level validation
+# (size cap, filename charset, mount_path rules) is intentionally left
+# to the API so SDK doesn't drift when server limits change.
+def load_config_file_mount(path: str, mount_path: str, filename: Optional[str] = None) -> ConfigFileMount:
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    return ConfigFileMount(filename=filename or os.path.basename(path), mount_path=mount_path, content=content)

--- a/centml/sdk/utils/config_file.py
+++ b/centml/sdk/utils/config_file.py
@@ -4,9 +4,10 @@ from typing import Optional
 from platform_api_python_client import ConfigFileMount
 
 
-# Load a file off disk into a ConfigFileMount. Field-level validation
-# (size cap, filename charset, mount_path rules) is intentionally left
-# to the API so SDK doesn't drift when server limits change.
+# Load a file off disk into a ConfigFileMount. `mount_path` is the parent
+# directory inside the container; the file lands at `mount_path/filename`.
+# Field-level validation (size cap, filename charset, mount_path rules) is
+# left to the API so SDK doesn't drift when server limits change.
 def load_config_file_mount(path: str, mount_path: str, filename: Optional[str] = None) -> ConfigFileMount:
     with open(path, "r", encoding="utf-8") as f:
         content = f.read()

--- a/examples/sdk/create_inference.py
+++ b/examples/sdk/create_inference.py
@@ -23,12 +23,14 @@ def main():
             max_unavailable=0,  # Keep all pods available during updates
             healthcheck="/",
             concurrency=10,
-            # Helper reads ./nginx.conf and wraps it; pass an inline
-            # ConfigFileMount(filename=..., mount_path=..., content=...) if
-            # the content is already in memory.
+            # Mounts ./default.conf at /etc/nginx/conf.d/default.conf. mount_path
+            # is the parent directory; filename defaults to os.path.basename(path)
+            # so the resulting file lands at mount_path/filename. Pass an inline
+            # ConfigFileMount(filename=..., mount_path=..., content=...) if the
+            # content is already in memory.
             config_file=load_config_file_mount(
-                path="./nginx.conf",
-                mount_path="/etc/nginx/conf.d/default.conf",
+                path="./default.conf",
+                mount_path="/etc/nginx/conf.d",
             ),
         )
         response = cclient.create_inference(request)

--- a/examples/sdk/create_inference.py
+++ b/examples/sdk/create_inference.py
@@ -28,10 +28,7 @@ def main():
             # so the resulting file lands at mount_path/filename. Pass an inline
             # ConfigFileMount(filename=..., mount_path=..., content=...) if the
             # content is already in memory.
-            config_file=load_config_file_mount(
-                path="./default.conf",
-                mount_path="/etc/nginx/conf.d",
-            ),
+            config_file=load_config_file_mount(path="./default.conf", mount_path="/etc/nginx/conf.d"),
         )
         response = cclient.create_inference(request)
         print("Create deployment response: ", response)

--- a/examples/sdk/create_inference.py
+++ b/examples/sdk/create_inference.py
@@ -1,6 +1,7 @@
 import centml
 from centml.sdk.api import get_centml_client
 from centml.sdk import DeploymentType, CreateInferenceV3DeploymentRequest, UserVaultType
+from centml.sdk.utils.config_file import load_config_file_mount
 
 
 def main():
@@ -22,6 +23,13 @@ def main():
             max_unavailable=0,  # Keep all pods available during updates
             healthcheck="/",
             concurrency=10,
+            # Helper reads ./nginx.conf and wraps it; pass an inline
+            # ConfigFileMount(filename=..., mount_path=..., content=...) if
+            # the content is already in memory.
+            config_file=load_config_file_mount(
+                path="./nginx.conf",
+                mount_path="/etc/nginx/conf.d/default.conf",
+            ),
         )
         response = cclient.create_inference(request)
         print("Create deployment response: ", response)

--- a/examples/sdk/create_inference_vllm.py
+++ b/examples/sdk/create_inference_vllm.py
@@ -1,0 +1,50 @@
+import centml
+from centml.sdk.api import get_centml_client
+from centml.sdk import CreateInferenceV3DeploymentRequest
+from centml.sdk.utils.config_file import load_config_file_mount
+
+
+def main():
+    with get_centml_client() as cclient:
+        # Mounts ./chat_template.jinja at /etc/vllm/chat_template.jinja and
+        # tells vLLM to use it via --chat-template. mount_path is the parent
+        # directory; filename defaults to os.path.basename(path).
+        request = CreateInferenceV3DeploymentRequest(
+            name="vllm-llama",
+            cluster_id=1000,
+            hardware_instance_id=1001,  # GPU instance
+            image_url="vllm/vllm-openai:latest",
+            port=8000,
+            min_replicas=1,
+            max_replicas=1,
+            initial_replicas=1,
+            max_surge=1,
+            max_unavailable=0,
+            healthcheck="/health",
+            concurrency=10,
+            env_vars={"HF_TOKEN": "<your-hf-token>"},
+            command=(
+                "python -m vllm.entrypoints.openai.api_server "
+                "--model meta-llama/Llama-3.2-3B-Instruct "
+                "--port 8000 "
+                "--chat-template /etc/vllm/chat_template.jinja"
+            ),
+            config_file=load_config_file_mount(path="./chat_template.jinja", mount_path="/etc/vllm"),
+        )
+        response = cclient.create_inference(request)
+        print("Create deployment response: ", response)
+
+        deployment = cclient.get_inference(response.id)
+        print("Deployment details: ", deployment)
+
+        '''
+        ### Pause the deployment
+        cclient.pause(deployment.id)
+
+        ### Delete the deployment
+        cclient.delete(deployment.id)
+        '''
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sdk/create_inference_vllm.py
+++ b/examples/sdk/create_inference_vllm.py
@@ -27,7 +27,7 @@ def main():
             healthcheck="/health",
             concurrency=10,
             env_vars={"HF_TOKEN": "<your-hf-token>"},
-            command="python -m vllm.entrypoints.openai.api_server --port 8000 --config /etc/vllm/vllm_config.yaml",
+            command="python3 -m vllm.entrypoints.openai.api_server --config /etc/vllm/vllm_config.yaml",
             config_file=load_config_file_mount(path="./vllm_config.yaml", mount_path="/etc/vllm"),
         )
         response = cclient.create_inference(request)

--- a/examples/sdk/create_inference_vllm.py
+++ b/examples/sdk/create_inference_vllm.py
@@ -6,9 +6,13 @@ from centml.sdk.utils.config_file import load_config_file_mount
 
 def main():
     with get_centml_client() as cclient:
-        # Mounts ./chat_template.jinja at /etc/vllm/chat_template.jinja and
-        # tells vLLM to use it via --chat-template. mount_path is the parent
-        # directory; filename defaults to os.path.basename(path).
+        # Mounts ./vllm_config.yaml at /etc/vllm/vllm_config.yaml and lets vLLM
+        # consume the whole config via --config. mount_path is the parent
+        # directory; filename defaults to os.path.basename(path) so the file
+        # lands at mount_path/filename. The sibling vllm_config.yaml in this
+        # directory shows a realistic Llama-3.1-8B + EAGLE3 speculative-decoding
+        # setup; edit it (model, dtype, tensor-parallel-size, speculative-config,
+        # etc.) to match the workload before deploying.
         request = CreateInferenceV3DeploymentRequest(
             name="vllm-llama",
             cluster_id=1000,
@@ -23,13 +27,8 @@ def main():
             healthcheck="/health",
             concurrency=10,
             env_vars={"HF_TOKEN": "<your-hf-token>"},
-            command=(
-                "python -m vllm.entrypoints.openai.api_server "
-                "--model meta-llama/Llama-3.2-3B-Instruct "
-                "--port 8000 "
-                "--chat-template /etc/vllm/chat_template.jinja"
-            ),
-            config_file=load_config_file_mount(path="./chat_template.jinja", mount_path="/etc/vllm"),
+            command="python -m vllm.entrypoints.openai.api_server --port 8000 --config /etc/vllm/vllm_config.yaml",
+            config_file=load_config_file_mount(path="./vllm_config.yaml", mount_path="/etc/vllm"),
         )
         response = cclient.create_inference(request)
         print("Create deployment response: ", response)

--- a/examples/sdk/default.conf
+++ b/examples/sdk/default.conf
@@ -1,0 +1,7 @@
+server {
+    listen 8080;
+    location / {
+        return 200 "hello from config_file\n";
+        add_header Content-Type text/plain;
+    }
+}

--- a/examples/sdk/vllm_config.yaml
+++ b/examples/sdk/vllm_config.yaml
@@ -1,0 +1,23 @@
+model: meta-llama/Llama-3.1-8B-Instruct
+tokenizer: meta-llama/Llama-3.1-8B-Instruct
+runner: generate
+dtype: auto
+gpu-memory-utilization: 0.9
+max-num-seqs: 2048
+tokenizer-mode: auto
+seed: 0
+tensor-parallel-size: 1
+pipeline-parallel-size: 1
+block-size: 16
+attention-backend: FLASHINFER
+distributed-executor-backend: uni
+enable-prefix-caching: true
+enable-chunked-prefill: true
+max-num-batched-tokens: 1024
+speculative-config:
+  method: eagle3
+  model: centml/EAGLE3-Llama3.1-8B-Instruct
+  num_speculative_tokens: 3
+  draft_tensor_parallel_size: 1
+enable-auto-tool-choice: true
+tool-call-parser: llama3_json

--- a/examples/sdk/vllm_config.yaml
+++ b/examples/sdk/vllm_config.yaml
@@ -1,3 +1,4 @@
+port: 8000
 model: meta-llama/Llama-3.1-8B-Instruct
 tokenizer: meta-llama/Llama-3.1-8B-Instruct
 runner: generate

--- a/tests/test_sdk_config_file_helper.py
+++ b/tests/test_sdk_config_file_helper.py
@@ -9,10 +9,10 @@ def test_default_filename_from_basename(tmp_path):
     src = tmp_path / "nginx.conf"
     src.write_text("server { listen 80; }\n")
 
-    mount = load_config_file_mount(str(src), "/etc/nginx/conf.d/default.conf")
+    mount = load_config_file_mount(str(src), "/etc/nginx/conf.d")
 
     assert mount.filename == "nginx.conf"
-    assert mount.mount_path == "/etc/nginx/conf.d/default.conf"
+    assert mount.mount_path == "/etc/nginx/conf.d"
     assert mount.content == "server { listen 80; }\n"
 
 
@@ -20,10 +20,10 @@ def test_explicit_filename_overrides_basename(tmp_path):
     src = tmp_path / "local.txt"
     src.write_text("payload")
 
-    mount = load_config_file_mount(str(src), "/app/etc/remote.conf", filename="remote.conf")
+    mount = load_config_file_mount(str(src), "/app/etc", filename="remote.conf")
 
     assert mount.filename == "remote.conf"
-    assert mount.mount_path == "/app/etc/remote.conf"
+    assert mount.mount_path == "/app/etc"
     assert mount.content == "payload"
 
 
@@ -31,7 +31,7 @@ def test_utf8_multibyte_content_roundtrips(tmp_path):
     src = tmp_path / "i18n.conf"
     src.write_text("配置内容 = 测试\n", encoding="utf-8")
 
-    mount = load_config_file_mount(str(src), "/etc/app/i18n.conf")
+    mount = load_config_file_mount(str(src), "/etc/app")
 
     assert mount.content == "配置内容 = 测试\n"
 

--- a/tests/test_sdk_config_file_helper.py
+++ b/tests/test_sdk_config_file_helper.py
@@ -1,0 +1,41 @@
+"""Tests for centml.sdk.utils.config_file.load_config_file_mount."""
+
+import pytest
+
+from centml.sdk.utils.config_file import load_config_file_mount
+
+
+def test_default_filename_from_basename(tmp_path):
+    src = tmp_path / "nginx.conf"
+    src.write_text("server { listen 80; }\n")
+
+    mount = load_config_file_mount(str(src), "/etc/nginx/conf.d/default.conf")
+
+    assert mount.filename == "nginx.conf"
+    assert mount.mount_path == "/etc/nginx/conf.d/default.conf"
+    assert mount.content == "server { listen 80; }\n"
+
+
+def test_explicit_filename_overrides_basename(tmp_path):
+    src = tmp_path / "local.txt"
+    src.write_text("payload")
+
+    mount = load_config_file_mount(str(src), "/app/etc/remote.conf", filename="remote.conf")
+
+    assert mount.filename == "remote.conf"
+    assert mount.mount_path == "/app/etc/remote.conf"
+    assert mount.content == "payload"
+
+
+def test_utf8_multibyte_content_roundtrips(tmp_path):
+    src = tmp_path / "i18n.conf"
+    src.write_text("配置内容 = 测试\n", encoding="utf-8")
+
+    mount = load_config_file_mount(str(src), "/etc/app/i18n.conf")
+
+    assert mount.content == "配置内容 = 测试\n"
+
+
+def test_missing_file_raises_filenotfound(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_config_file_mount(str(tmp_path / "does-not-exist.conf"), "/etc/x")

--- a/tests/test_sdk_config_file_helper.py
+++ b/tests/test_sdk_config_file_helper.py
@@ -39,3 +39,14 @@ def test_utf8_multibyte_content_roundtrips(tmp_path):
 def test_missing_file_raises_filenotfound(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_config_file_mount(str(tmp_path / "does-not-exist.conf"), "/etc/x")
+
+
+def test_preserves_crlf_line_endings(tmp_path):
+    # Windows-authored configs use \r\n; the helper must not silently
+    # normalize them to \n when uploading to the server.
+    src = tmp_path / "windows.conf"
+    src.write_bytes(b"line1\r\nline2\r\n")
+
+    mount = load_config_file_mount(str(src), "/etc/app")
+
+    assert mount.content == "line1\r\nline2\r\n"


### PR DESCRIPTION
## Summary

- Bump `platform-api-python-client` `4.9.0` → `4.10.0` so `ConfigFileMount` is importable (verified by unpacking the wheel from PyPI; the `models/config_file_mount.py` file is present).
- New helper `centml/sdk/utils/config_file.py` exposing `load_config_file_mount(path, mount_path, filename=None) -> ConfigFileMount` — reads a UTF-8 text file off disk and wraps it. Pattern mirrors the existing `centml/sdk/utils/client_certs.py` (free function, no class wrapping of generated client models).
- Helper is deliberately validation-free — content size cap, filename charset, mount_path rules are owned by the server (platform PRs [#3656](https://github.com/CentML/platform/pull/3656) and [#3667](https://github.com/CentML/platform/pull/3667)). Keeping limits server-only avoids SDK drift when server limits change.
- `examples/sdk/create_inference.py` updated to demonstrate the helper in context; all existing fields preserved.

No CLI changes. No re-export from `centml.sdk` top-level (consistent with how `client_certs` is consumed today).

## Why this shape

| Decision | Why |
| --- | --- |
| Free function (not subclass `ConfigFileMount`) | Matches `client_certs.py`; no precedent for subclassing generated models. |
| `filename` defaults to `os.path.basename(path)` | Common case is mounting `nginx.conf` as `nginx.conf`. |
| `mount_path` has no default | The in-container path is the whole point of the field. |
| UTF-8 text mode read | Server contract is `content: str`. Binary configs not in scope. |
| No client-side validation | Server returns 422 with byte counts on overrun (PR #3667); SDK should not drift from server. |
| `==4.10.0` exact pin | Matches existing `requirements.txt` discipline. |

## Test plan

- [x] `pytest --sanity tests/` — 47 passed (4 new tests in `test_sdk_config_file_helper.py`)
- [x] Black `--check` clean on new files
- [x] mypy clean on new files (pre-existing `auth.py` import-untyped is unchanged)
- [x] PyPI wheel for `platform-api-python-client==4.10.0` verified to ship `models/config_file_mount.py`
- [x] **Manual smoke on local cluster**: created inference_v3 with `config_file=load_config_file_mount(tmp_conf, "/etc/nginx/conf.d/default.conf")` against `localhost:16000` (minikube). `get_inference(id).config_file` roundtripped byte-perfect — `filename` matched basename, `mount_path` preserved, `content` matched the source file. Cleaned up via `delete()`.

| Unit test | Asserts |
| --- | --- |
| `test_default_filename_from_basename` | filename defaults to `basename(path)`, content + mount_path passthrough |
| `test_explicit_filename_overrides_basename` | explicit `filename` arg wins |
| `test_utf8_multibyte_content_roundtrips` | CJK text round-trips byte-perfect (catches binary-mode regression) |
| `test_missing_file_raises_filenotfound` | helper does not swallow I/O errors |